### PR TITLE
Update translation.json

### DIFF
--- a/frontend/src/app/locales/ja-JP/translation.json
+++ b/frontend/src/app/locales/ja-JP/translation.json
@@ -9,13 +9,13 @@
       "ja-JP": "日本語"
     },
     "actions": {
-      "apply": "適用",
+      "apply": "インポート",
       "cancel": "キャンセル",
       "close": "閉じる",
       "copy": "コピー",
       "delete": "削除",
       "export": "エクスポート",
-      "import": "インポート",
+      "import": "適用",
       "refresh": "更新",
       "retry": "再試行",
       "save": "保存"


### PR DESCRIPTION
インポート部分のボタンの位置を逆にしてしまいました

一通りチェックしました、ここのボタンの位置以外は特に不具合を見つかりませんでしたので、次のリリースで修正されましたら日本語の翻訳はひと段落になると思います