### PR TITLE
feat(ui): add window materials and refine page transitions

### DIFF
--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import {
   Copy,
   LineChart,
@@ -63,7 +63,7 @@ function getTabTransitionDirection(fromTab: ActiveTab, toTab: ActiveTab) {
   return toIndex > fromIndex ? 1 : -1;
 }
 
-const TAB_CONTENT_VARIANTS = {
+const TAB_CONTENT_VARIANTS: Variants = {
   enter: (direction: number) => ({
     opacity: 0,
     y: direction === 0 ? 8 : direction * 18,
@@ -71,10 +71,18 @@ const TAB_CONTENT_VARIANTS = {
   center: {
     opacity: 1,
     y: 0,
+    transition: {
+      duration: 0.19,
+      ease: [0.22, 1, 0.36, 1],
+    },
   },
   exit: (direction: number) => ({
     opacity: 0,
     y: direction === 0 ? -6 : direction * -14,
+    transition: {
+      duration: 0.16,
+      ease: [0.22, 1, 0.36, 1],
+    },
   }),
 };
 
@@ -810,10 +818,7 @@ export default function AppShell({
                 initial="enter"
                 animate="center"
                 exit="exit"
-                transition={{
-                  duration: 0.2,
-                  ease: [0.22, 1, 0.36, 1],
-                }}
+                data-page-reveal="cards"
                 className="w-full min-w-0 px-1 pb-2 will-change-transform"
               >
                 {contentMap[activeTab]}

--- a/frontend/src/app/components/ControlPanel.tsx
+++ b/frontend/src/app/components/ControlPanel.tsx
@@ -537,7 +537,9 @@ export default function ControlPanel({ config, onConfigChange, isConnected, fanD
   const windowBlurOptions = useMemo(
     () => [
       { value: 'auto', label: t('controlPanel.options.windowBlur.auto') },
-      { value: 'on', label: t('controlPanel.options.windowBlur.on') },
+      { value: 'acrylic', label: t('controlPanel.options.windowBlur.acrylic') },
+      { value: 'mica', label: t('controlPanel.options.windowBlur.mica') },
+      { value: 'tabbed', label: t('controlPanel.options.windowBlur.tabbed') },
       { value: 'off', label: t('controlPanel.options.windowBlur.off') },
     ],
     [locale, t],
@@ -1705,7 +1707,7 @@ export default function ControlPanel({ config, onConfigChange, isConnected, fanD
           >
             <div className="w-36">
               <Select
-                value={((config as any).windowBlur || 'auto') as string}
+                value={((config as any).windowBlur === 'on' ? 'mica' : ((config as any).windowBlur || 'auto')) as string}
                 onChange={(v: string | number) => handleWindowBlurChange(String(v))}
                 options={windowBlurOptions}
                 size="sm"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -158,6 +158,41 @@
   display: none !important;
 }
 
+@keyframes page-card-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+[data-page-reveal="cards"] > * > * {
+  animation: page-card-fade 0.285s ease-out both;
+}
+
+[data-page-reveal="cards"] > * > :nth-child(2) {
+  animation-delay: 0.08s;
+}
+
+[data-page-reveal="cards"] > * > :nth-child(3) {
+  animation-delay: 0.16s;
+}
+
+[data-page-reveal="cards"] > * > :nth-child(4) {
+  animation-delay: 0.24s;
+}
+
+[data-page-reveal="cards"] > * > :nth-child(5) {
+  animation-delay: 0.32s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-page-reveal="cards"] > * > * {
+    animation: none;
+  }
+}
+
 /* body 画布必须透明，否则系统材质会被 @layer base 的 bg-background 完全挡住 */
 body:has(.glacier-native-backdrop) {
   background: transparent;

--- a/frontend/src/app/locales/en-US/translation.json
+++ b/frontend/src/app/locales/en-US/translation.json
@@ -721,8 +721,8 @@
       "reconnectTitle": "Keep config after reconnect",
       "reconnectDescription": "Continue using the app configuration after reconnecting",
       "reconnectTip": "Recommended to prevent fallback to the device default mode after disconnects",
-      "blurTitle": "Window blur effect",
-      "blurDescription": "Acrylic/Mica translucency. Default: on for Windows 11, off for Windows 10. Takes effect after restart.",
+      "blurTitle": "Window material",
+      "blurDescription": "Choose Acrylic, Mica, or Mica Alt. Changes take effect after restart.",
       "suspendFanOffTitle": "Power off on sleep",
       "suspendFanOffDescription": "When the system sleeps or hibernates, set the fan to 0 RPM and turn off the gear light and RGB."
     },
@@ -848,7 +848,9 @@
       },
       "windowBlur": {
         "auto": "Auto (by system)",
-        "on": "On",
+        "acrylic": "Acrylic",
+        "mica": "Mica",
+        "tabbed": "Mica Alt",
         "off": "Off"
       }
     }

--- a/frontend/src/app/locales/ja-JP/translation.json
+++ b/frontend/src/app/locales/ja-JP/translation.json
@@ -720,8 +720,8 @@
       "reconnectTitle": "設定を維持",
       "reconnectDescription": "再接続後もアプリ設定を引き続き使用します",
       "reconnectTip": "切断後にデバイス既定モードへ戻るのを防ぐため、有効化を推奨します",
-      "blurTitle": "ウィンドウのぼかし効果",
-      "blurDescription": "アクリル/マイカの半透明効果。既定は Windows 11 でオン、Windows 10 でオフ。変更後は再起動で反映されます。",
+      "blurTitle": "ウィンドウ素材",
+      "blurDescription": "アクリル、マイカ、またはマイカ Alt を選択します。変更は再起動後に反映されます。",
       "suspendFanOffTitle": "スリープ時に停止",
       "suspendFanOffDescription": "システムがスリープ/休止状態になると、ファンを 0 RPM にし、ギアライトと RGB をオフにします。"
     },
@@ -847,7 +847,9 @@
       },
       "windowBlur": {
         "auto": "自動（システムに従う）",
-        "on": "オン",
+        "acrylic": "アクリル",
+        "mica": "マイカ",
+        "tabbed": "マイカ Alt",
         "off": "オフ"
       }
     }

--- a/frontend/src/app/locales/zh-CN/translation.json
+++ b/frontend/src/app/locales/zh-CN/translation.json
@@ -721,8 +721,8 @@
       "reconnectTitle": "断连保持配置",
       "reconnectDescription": "重连后继续使用 APP 配置",
       "reconnectTip": "推荐开启，防止断连后进入设备默认模式",
-      "blurTitle": "窗口模糊效果",
-      "blurDescription": "亚克力/云母半透明效果。默认 Windows 11 开启、Windows 10 关闭，修改后需重启应用生效。",
+      "blurTitle": "窗口材质",
+      "blurDescription": "选择亚克力、云母或云母 Alt 材质，修改后需重启应用生效。",
       "suspendFanOffTitle": "休眠时自动关闭",
       "suspendFanOffDescription": "系统进入睡眠/休眠时，将风扇转速归零并关闭挡位灯与 RGB。"
     },
@@ -848,7 +848,9 @@
       },
       "windowBlur": {
         "auto": "自动（随系统）",
-        "on": "开启",
+        "acrylic": "亚克力",
+        "mica": "云母",
+        "tabbed": "云母 Alt",
         "off": "关闭"
       }
     }

--- a/frontend/src/app/types/app.ts
+++ b/frontend/src/app/types/app.ts
@@ -82,7 +82,7 @@ export interface AppConfig {
   cpuSensor?: string;
   cpuSensors?: string[];       // CPU 多传感器选择(多核平均)；为空则按 cpuSensor 单选/自动
   gpuSensor?: string;
-  windowBlur?: 'auto' | 'on' | 'off'; // 窗口模糊效果(Win11 默认开, Win10 默认关)
+  windowBlur?: 'auto' | 'on' | 'acrylic' | 'mica' | 'tabbed' | 'off'; // 窗口材质；on 为旧版兼容值
   suspendFanOff?: boolean;     // 系统休眠时归零转速并关闭挡位灯/RGB
   configPath: string;          // 配置文件路径
   manualGear: string;          // 手动挡位设置

--- a/internal/guiapp/window_backdrop.go
+++ b/internal/guiapp/window_backdrop.go
@@ -10,20 +10,21 @@ import (
 // 决定背景透明度，确保与窗口的真实材质一致(模糊设置更改需重启才生效)。
 var resolvedBlurEnabled bool
 
-// ResolveWindowsOptions 根据用户配置(windowBlur)与系统版本决定窗口的模糊(云母/亚克力)效果。
+// ResolveWindowsOptions 根据用户配置(windowBlur)与系统版本决定窗口材质。
 //
-//   - on   : 始终启用模糊(透明 + 云母背景)。
-//   - off  : 关闭模糊(不透明窗口)。
-//   - auto : Win11 启用、Win10 关闭(模糊设置的默认值)。
+//   - auto：Win11 使用云母，Win10 关闭。
+//   - on：兼容旧配置，继续使用云母。
+//   - acrylic/mica/tabbed/off：使用对应材质。
 //
 // 该选项在 Wails 中只能于窗口创建时生效，更改后需重启应用。
 func ResolveWindowsOptions() *windows.Options {
-	resolvedBlurEnabled = blurEnabledForCurrentSystem(resolveWindowBlurMode())
+	backdrop := backdropTypeForMode(resolveWindowBlurMode(), isWindows11())
+	resolvedBlurEnabled = backdrop != windows.None
 	if resolvedBlurEnabled {
 		return &windows.Options{
 			WebviewIsTransparent: true,
 			WindowIsTranslucent:  true,
-			BackdropType:         windows.Mica,
+			BackdropType:         backdrop,
 		}
 	}
 	return &windows.Options{
@@ -39,14 +40,23 @@ func (a *App) WindowBlurEnabled() bool {
 	return resolvedBlurEnabled
 }
 
-func blurEnabledForCurrentSystem(mode string) bool {
-	switch mode {
+func backdropTypeForMode(mode string, windows11 bool) windows.BackdropType {
+	switch types.NormalizeWindowBlur(mode) {
+	case types.WindowBlurAcrylic:
+		return windows.Acrylic
+	case types.WindowBlurMica:
+		return windows.Mica
+	case types.WindowBlurTabbed:
+		return windows.Tabbed
 	case types.WindowBlurOn:
-		return true
+		return windows.Mica
 	case types.WindowBlurOff:
-		return false
-	default: // auto: Win11 开启, Win10 关闭
-		return isWindows11()
+		return windows.None
+	default:
+		if windows11 {
+			return windows.Mica
+		}
+		return windows.None
 	}
 }
 

--- a/internal/guiapp/window_backdrop_test.go
+++ b/internal/guiapp/window_backdrop_test.go
@@ -1,0 +1,32 @@
+package guiapp
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/options/windows"
+)
+
+func TestBackdropTypeForMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		windows11 bool
+		want      windows.BackdropType
+	}{
+		{name: "auto on Windows 11", mode: "auto", windows11: true, want: windows.Mica},
+		{name: "auto on Windows 10", mode: "auto", windows11: false, want: windows.None},
+		{name: "legacy on", mode: "on", windows11: true, want: windows.Mica},
+		{name: "acrylic", mode: "acrylic", windows11: true, want: windows.Acrylic},
+		{name: "mica", mode: "mica", windows11: true, want: windows.Mica},
+		{name: "mica alt", mode: "tabbed", windows11: true, want: windows.Tabbed},
+		{name: "off", mode: "off", windows11: true, want: windows.None},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backdropTypeForMode(tt.mode, tt.windows11); got != tt.want {
+				t.Fatalf("backdropTypeForMode(%q, %v) = %v, want %v", tt.mode, tt.windows11, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/types/normalize_test.go
+++ b/internal/types/normalize_test.go
@@ -52,6 +52,9 @@ func TestNormalizeWindowBlur(t *testing.T) {
 	}{
 		{WindowBlurAuto, WindowBlurAuto},
 		{WindowBlurOn, WindowBlurOn},
+		{"acrylic", "acrylic"},
+		{"mica", "mica"},
+		{"tabbed", "tabbed"},
 		{WindowBlurOff, WindowBlurOff},
 		{"invalid", WindowBlurAuto},
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -32,6 +32,12 @@ const (
 	WindowBlurAuto = "auto"
 	// WindowBlurOn 强制开启窗口模糊效果。
 	WindowBlurOn = "on"
+	// WindowBlurAcrylic 使用亚克力窗口材质。
+	WindowBlurAcrylic = "acrylic"
+	// WindowBlurMica 使用云母窗口材质。
+	WindowBlurMica = "mica"
+	// WindowBlurTabbed 使用云母 Alt（Tabbed）窗口材质。
+	WindowBlurTabbed = "tabbed"
 	// WindowBlurOff 强制关闭窗口模糊效果。
 	WindowBlurOff = "off"
 )
@@ -39,8 +45,8 @@ const (
 // NormalizeWindowBlur 归一化窗口模糊效果设置，非法值回退为 auto。
 func NormalizeWindowBlur(mode string) string {
 	switch mode {
-	case WindowBlurOn:
-		return WindowBlurOn
+	case WindowBlurOn, WindowBlurAcrylic, WindowBlurMica, WindowBlurTabbed:
+		return mode
 	case WindowBlurOff:
 		return WindowBlurOff
 	default:
@@ -487,7 +493,7 @@ type AppConfig struct {
 	CpuSensor                string                    `json:"cpuSensor"`                // CPU 传感器选择: auto 或传感器 key
 	CpuSensors               []string                  `json:"cpuSensors"`               // CPU 多传感器选择(多核平均): 为空则按 cpuSensor 单选/自动
 	GpuSensor                string                    `json:"gpuSensor"`                // GPU 传感器选择: auto 或传感器 key
-	WindowBlur               string                    `json:"windowBlur"`               // 窗口模糊效果: auto/on/off (Win11 默认开, Win10 默认关)
+	WindowBlur               string                    `json:"windowBlur"`               // 窗口材质: auto/acrylic/mica/tabbed/off；兼容旧值 on
 	SuspendFanOff            bool                      `json:"suspendFanOff"`            // 系统休眠/睡眠时自动归零转速并关闭挡位灯与 RGB
 	ConfigPath               string                    `json:"configPath"`               // 配置文件路径
 	ManualGear               string                    `json:"manualGear"`               // 手动挡位设置


### PR DESCRIPTION
## Summary

- 新增窗口材质选择：自动、Acrylic、Mica、Mica Alt 和关闭，并兼容旧版 `auto/on/off` 配置。
- 优化页面切换动画：缩短进入/退出时长，增加卡片渐进淡入，并支持 `prefers-reduced-motion`。

## Validation

- `go test ./internal/types ./internal/guiapp -count=1`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run build`
- 中、英、日三份 locale JSON 解析检查

## Compatibility

窗口材质修改后需重启生效；旧版 `on` 配置继续按 Mica 处理。