### PR TITLE
修复 UI：弹窗打开时顶栏状态标签未正常变暗

### DIFF
--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -184,16 +184,22 @@ function TitleBar({
   onClose: () => void;
 }) {
   return (
-    <div
-      // z-[9999]：保证最小化/最大化/关闭三键始终高于 Dialog 遮罩（z-50）等弹层并可交互
-      className="glacier-titlebar pointer-events-auto absolute right-0 top-0 z-[9999] flex h-10 items-center justify-between bg-background transition-[left] duration-300 ease-out"
-      style={{ ...DRAG_STYLE, left: leftOffset }}
-      onDoubleClick={onToggleMaximise}
-    >
-      <div className="flex h-full min-w-0 flex-1 items-center px-3 pt-1">
-        {leftSlot}
+    <>
+      <div
+        className="glacier-titlebar pointer-events-auto absolute right-0 top-0 z-40 flex h-10 items-center bg-background pr-32 transition-[left] duration-300 ease-out"
+        style={{ ...DRAG_STYLE, left: leftOffset }}
+        onDoubleClick={onToggleMaximise}
+      >
+        <div className="flex h-full min-w-0 flex-1 items-center px-3 pt-1">
+          {leftSlot}
+        </div>
       </div>
-      <div className="flex h-full items-center gap-0.5 pr-1" style={NO_DRAG_STYLE}>
+
+      {/* Keep only native window controls interactive above modal overlays. */}
+      <div
+        className="glacier-titlebar pointer-events-auto absolute right-0 top-0 z-[9999] flex h-10 items-center gap-0.5 bg-transparent pr-1"
+        style={NO_DRAG_STYLE}
+      >
         <TitleBarButton icon={<Minus className="h-3.5 w-3.5" />} label={minimizeLabel} onClick={onMinimise} />
         <TitleBarButton
           icon={isMaximised ? <Copy className="h-3 w-3" /> : <Square className="h-3 w-3" />}
@@ -202,7 +208,7 @@ function TitleBar({
         />
         <TitleBarButton icon={<X className="h-3.5 w-3.5" />} label={closeLabel} onClick={onClose} danger />
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 概要

修复 Windows 下使用内置浅色或深色主题时，打开弹窗后顶栏状态标签仍保持突出显示的问题。

## 问题

在内置浅色或深色主题下，打开“新建曲线方案”或“管理曲线方案”等弹窗时，蓝牙连接状态、当前模式、温度和风扇转速这四个状态标签仍位于弹窗遮罩之上。

因此，状态标签保持原有亮度，而应用的其他内容已经被遮罩压暗，看起来像是状态标签被单独高亮。

目前该问题是在内置浅色和深色主题下观察到的。自定义主题可能拥有自己的顶栏背景和层级设置，通常不会出现相同的视觉问题。

## 原因

Windows 自绘顶栏之前将状态标签和最小化、最大化、关闭按钮放在了同一个高层级容器中。

窗口控制按钮需要在弹窗打开时继续可用，但状态标签属于信息展示内容，应当和其他页面内容一样被弹窗遮罩压暗。

## 修复方式

- 将顶栏状态区域与窗口控制按钮拆分为不同层级。
- 将状态区域放置在弹窗遮罩下方。
- 保持最小化、最大化和关闭按钮位于遮罩上方。
- 将高层窗口控制容器设为透明，避免弹窗打开时右上角出现未变暗的背景块。
- 保留顶栏拖动和双击最大化行为。

## 验证

- [x] 内置浅色主题
- [x] 内置深色主题
- [x] 窗口材质开启
- [x] 窗口材质关闭
- [x] 新建曲线方案弹窗
- [x] 管理曲线方案弹窗
- [x] 窗口控制按钮仍可点击
- [x] 自定义 THRM 主题未出现回归

## 修改范围

本 PR 只处理顶栏层级问题，针对内置浅色和深色主题下观察到的状态标签显示异常。

本 PR 不修改弹窗逻辑、应用配置、自定义主题文件或 RTSS 功能。