### PR TITLE
fix: reinstall PawnIO after THRM exits

### DIFF
--- a/frontend/src/app/components/ControlPanel.tsx
+++ b/frontend/src/app/components/ControlPanel.tsx
@@ -681,13 +681,12 @@ export default function ControlPanel({ config, onConfigChange, isConnected, fanD
       if (result?.bridgeWarning) {
         toast.warning(t('controlPanel.debug.toasts.bridgeWarning', { warning: result.bridgeWarning }));
       }
-      await fetchDebugInfo();
     } catch (error) {
       toast.error(t('controlPanel.debug.toasts.reinstallFailed', { error: getErrorMessage(error) }));
     } finally {
       setLoading('pawnIOReinstall', false);
     }
-  }, [fetchDebugInfo, t]);
+  }, [t]);
 
   const handleExportDiagnostics = useCallback(async () => {
     setLoading('diagnosticsExport', true);

--- a/internal/coreapp/app.go
+++ b/internal/coreapp/app.go
@@ -94,8 +94,6 @@ const (
 	systemResumeDetectionCeiling = 45 * time.Second                                             // 系统恢复检测阈值上限
 	systemResumeRecoveryCooldown = 5 * time.Second                                              // 系统恢复后自动重连的冷却时间
 	suspendCleanupGrace          = 2 * time.Second                                              // 挂起清理宽限时间
-	pawnIOInstallerTimeout       = 90 * time.Second                                             // PawnIO 安装程序超时时间
-	pawnIOAlreadyExistsExitCode  = 183                                                          // PawnIO 安装程序退出码，表示已存在安装
 	pawnIORegistryPath           = `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO` // PawnIO 注册表路径
 )
 

--- a/internal/coreapp/pawnio_reinstall_windows.go
+++ b/internal/coreapp/pawnio_reinstall_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package coreapp
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func buildPawnIOReinstallScript(installerPath, guiPath string, corePID int) string {
+	escape := func(value string) string {
+		value = strings.NewReplacer("^", "^^", "&", "^&", "<", "^<", ">", "^>", "|", "^|").Replace(value)
+		value = strings.ReplaceAll(value, "%", "%%")
+		return strings.ReplaceAll(value, "!", "")
+	}
+
+	var script strings.Builder
+	writeLine := func(line string) { script.WriteString(line); script.WriteString("\r\n") }
+	writeLine("@echo off")
+	writeLine("setlocal enableextensions enabledelayedexpansion")
+	writeLine(`set "PATH=%SystemRoot%\System32;%PATH%"`)
+	writeLine("title THRM PawnIO reinstall")
+	writeLine(fmt.Sprintf(`set "INSTALLER_FILE=%s"`, escape(installerPath)))
+	writeLine(fmt.Sprintf(`set "GUI_FILE=%s"`, escape(guiPath)))
+	writeLine(":waitcore")
+	writeLine(fmt.Sprintf(`tasklist /FI "PID eq %d" /NH 2>nul | find "%d" >nul`, corePID, corePID))
+	writeLine("if not errorlevel 1 (")
+	writeLine("  timeout /t 1 /nobreak >nul")
+	writeLine("  goto waitcore")
+	writeLine(")")
+	writeLine(`set "PAWNIO_PRESENT=0"`)
+	writeLine(`reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO" /reg:64 >nul 2>&1 && set "PAWNIO_PRESENT=1"`)
+	writeLine(`reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO" /reg:32 >nul 2>&1 && set "PAWNIO_PRESENT=1"`)
+	writeLine(`if "!PAWNIO_PRESENT!"=="1" (`)
+	writeLine(`  start "" /wait "%INSTALLER_FILE%" -uninstall -silent`)
+	writeLine(`  if not "!ERRORLEVEL!"=="0" echo PawnIO uninstall returned !ERRORLEVEL!; continuing with installation.`)
+	writeLine(")")
+	writeLine(`start "" /wait "%INSTALLER_FILE%" -install -silent`)
+	writeLine(`set "INSTALL_EXIT=!ERRORLEVEL!"`)
+	writeLine(`if not "!INSTALL_EXIT!"=="0" timeout /t 6 /nobreak >nul`)
+	writeLine(`if exist "%GUI_FILE%" start "" "%GUI_FILE%"`)
+	writeLine(`del "%~f0" >nul 2>&1`)
+	writeLine(`rmdir "%~dp0" >nul 2>&1`)
+	return script.String()
+}
+
+func launchPawnIOReinstallScript(installerPath, guiPath string, corePID int) error {
+	scriptDir, err := os.MkdirTemp("", "THRM-pawnio-reinstall-")
+	if err != nil {
+		return fmt.Errorf("create PawnIO reinstall directory: %w", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "run-pawnio-reinstall.bat")
+	if err := os.WriteFile(scriptPath, []byte(buildPawnIOReinstallScript(installerPath, guiPath, corePID)), 0o644); err != nil {
+		_ = os.RemoveAll(scriptDir)
+		return fmt.Errorf("write PawnIO reinstall script: %w", err)
+	}
+
+	cmd := exec.Command("cmd", "/d", "/c", "start", "", "cmd", "/d", "/c", scriptPath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000 | syscall.CREATE_NEW_PROCESS_GROUP}
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(scriptDir)
+		return fmt.Errorf("launch PawnIO reinstall script: %w", err)
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
+	}
+	return nil
+}

--- a/internal/coreapp/pawnio_reinstall_windows_test.go
+++ b/internal/coreapp/pawnio_reinstall_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package coreapp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPawnIOReinstallScript(t *testing.T) {
+	script := buildPawnIOReinstallScript(`C:\THRM\drivers\PawnIO\PawnIO_setup.exe`, `C:\THRM\THRM.exe`, 4242)
+	for _, want := range []string{
+		`PID eq 4242`,
+		`reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO" /reg:64`,
+		`if "!PAWNIO_PRESENT!"=="1" (`,
+		`-uninstall -silent`,
+		`-install -silent`,
+		`start "" "%GUI_FILE%"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("reinstall script missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Index(script, `-install -silent`) > strings.Index(script, `start "" "%GUI_FILE%"`) {
+		t.Fatalf("THRM restart was emitted before the PawnIO install step:\n%s", script)
+	}
+}

--- a/internal/coreapp/platform_windows.go
+++ b/internal/coreapp/platform_windows.go
@@ -3,119 +3,56 @@
 package coreapp
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/TIANLI0/THRM/internal/appmeta"
 	"github.com/TIANLI0/THRM/internal/config"
 	"golang.org/x/sys/windows/registry"
 )
 
-// ReinstallPawnIO runs the bundled PawnIO installer stored under the install directory.
+// ReinstallPawnIO schedules the bundled PawnIO installer after THRM exits.
 func (a *CoreApp) ReinstallPawnIO() (map[string]any, error) {
 	installDir := config.GetInstallDir()
 	installerPath := appmeta.FirstExistingPath(appmeta.PawnIOInstallerCandidates(installDir))
 	if installerPath == "" {
 		return nil, fmt.Errorf("未找到 PawnIO 安装包，已尝试路径: %v", appmeta.PawnIOInstallerCandidates(installDir))
 	}
+	guiPath := appmeta.FirstExistingPath(appmeta.GUIExecutableCandidates(installDir))
+	if guiPath == "" {
+		return nil, fmt.Errorf("未找到 THRM 主程序，已尝试路径: %v", appmeta.GUIExecutableCandidates(installDir))
+	}
 
 	result := map[string]any{
-		"success": false,
-		"path":    installerPath,
+		"success":     false,
+		"path":        installerPath,
+		"restartPath": guiPath,
 	}
 	installedVersionBefore := readInstalledPawnIOVersion()
 	if installedVersionBefore != "" {
 		result["installedVersionBefore"] = installedVersionBefore
 	}
 
-	a.logInfo("开始重新安装 PawnIO: %s", installerPath)
-	a.bridgeManager.Stop()
-
-	if installedVersionBefore != "" {
-		a.logInfo("检测到已安装 PawnIO (版本: %s)，先执行卸载再安装", installedVersionBefore)
-		uninstallStep, uninstallErr := a.runPawnIOInstaller(installerPath, "uninstall", "-uninstall", "-silent")
-		result["uninstall"] = uninstallStep
-		if uninstallErr != nil {
-			if isPawnIOInstallerTimeout(uninstallErr) {
-				result["error"] = "PawnIO 卸载超时"
-				return result, fmt.Errorf("PawnIO 卸载超时，请稍后检查驱动状态或手动运行 %s", installerPath)
-			}
-			result["uninstallWarning"] = uninstallErr.Error()
-			a.logError("PawnIO 卸载返回错误，将继续尝试安装: %v", uninstallErr)
-		}
+	if err := launchPawnIOReinstallScript(installerPath, guiPath, os.Getpid()); err != nil {
+		result["error"] = err.Error()
+		return result, err
 	}
 
-	installStep, installErr := a.runPawnIOInstaller(installerPath, "install", "-install", "-silent")
-	result["install"] = installStep
-	installedVersionAfter := readInstalledPawnIOVersion()
-	if installedVersionAfter != "" {
-		result["installedVersionAfter"] = installedVersionAfter
-	}
-
-	if installErr != nil {
-		if isPawnIOInstallerTimeout(installErr) {
-			result["error"] = "PawnIO 安装超时"
-			return result, fmt.Errorf("PawnIO 安装超时，请稍后检查驱动状态或手动运行 %s", installerPath)
-		}
-
-		if pawnIOInstallerExitCode(installErr) == pawnIOAlreadyExistsExitCode && installedVersionAfter != "" {
-			result["alreadyInstalled"] = true
-			result["warning"] = "PawnIO 安装器返回 183（已存在），已确认系统中仍有 PawnIO 安装记录。"
-			a.logInfo("PawnIO 安装器返回 183，检测到已安装版本 %s，按非致命结果处理", installedVersionAfter)
-		} else {
-			result["error"] = installErr.Error()
-			return result, formatPawnIOInstallerError("PawnIO 安装失败", installErr, installStep)
-		}
-	} else {
-		a.logInfo("PawnIO 安装程序执行完成")
-	}
-
+	a.logInfo("已安排重新安装 PawnIO，正在退出 THRM: %s", installerPath)
 	result["success"] = true
-	bridgeResult, bridgeErr := a.bridgeManager.RestartPawnIO()
-	if bridgeErr != nil {
-		result["bridgeWarning"] = bridgeErr.Error()
-		a.logError("PawnIO 安装后重新初始化温度监控失败: %v", bridgeErr)
-	} else {
-		result["bridge"] = bridgeResult
-	}
+	result["scheduled"] = true
+	a.safeGo("pawnio-reinstall-quit", func() {
+		time.Sleep(800 * time.Millisecond)
+		a.onQuitRequest()
+	})
 
 	return result, nil
 }
-
-func (a *CoreApp) runPawnIOInstaller(installerPath, action string, args ...string) (map[string]any, error) {
-	ctx, cancel := context.WithTimeout(a.ctx, pawnIOInstallerTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, installerPath, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	output, err := cmd.CombinedOutput()
-	outputText := strings.TrimSpace(string(output))
-	step := map[string]any{
-		"action":   action,
-		"args":     args,
-		"success":  err == nil,
-		"exitCode": pawnIOInstallerExitCode(err),
-	}
-	if outputText != "" {
-		step["output"] = outputText
-	}
-	if ctx.Err() == context.DeadlineExceeded {
-		step["timeout"] = true
-		step["success"] = false
-		return step, ctx.Err()
-	}
-	if err != nil {
-		step["error"] = err.Error()
-	}
-	return step, err
-}
-
 func readInstalledPawnIOVersion() string {
 	for _, access := range []uint32{registry.QUERY_VALUE | registry.WOW64_64KEY, registry.QUERY_VALUE | registry.WOW64_32KEY} {
 		key, err := registry.OpenKey(registry.LOCAL_MACHINE, pawnIORegistryPath, access)
@@ -129,28 +66,6 @@ func readInstalledPawnIOVersion() string {
 		}
 	}
 	return ""
-}
-
-func pawnIOInstallerExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return exitErr.ExitCode()
-	}
-	return -1
-}
-
-func isPawnIOInstallerTimeout(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded)
-}
-
-func formatPawnIOInstallerError(prefix string, err error, step map[string]any) error {
-	if output, ok := step["output"].(string); ok && output != "" {
-		return fmt.Errorf("%s: %v；输出: %s", prefix, err, output)
-	}
-	return fmt.Errorf("%s: %v", prefix, err)
 }
 
 // launchGUI 启动 GUI 程序


### PR DESCRIPTION
## Summary / 更新内容

- PawnIO 重装改为在 THRM 退出后由独立脚本执行。
  PawnIO reinstall now runs from a detached script after THRM exits.

- 若系统中已有 PawnIO，脚本会先卸载；未检测到安装记录或卸载失败时仍会继续安装。
  The script uninstalls an existing PawnIO installation, while a missing entry or uninstall failure does not block installation.

- 安装完成后自动重新打开 THRM；安装器返回错误时也会尝试重新打开。
  THRM restarts after installation and is also restarted when the installer reports an error.

- 保持现有界面文字、按钮和 IPC 方法不变。
  Existing UI copy, button labels, and IPC method names remain unchanged.

## Why / 背景

当前重装流程在 THRM 仍运行时直接执行安装器，可能与仍被占用的温度读取组件发生冲突。

The previous flow invoked the installer while THRM was still running, which could conflict with active temperature-reading components.

## How to validate / 验证方式

1. 在 THRM 中执行现有的 PawnIO 重装操作。
   Trigger the existing PawnIO reinstall action in THRM.

2. 确认 THRM 在请求成功后退出。
   Confirm THRM exits after the request succeeds.

3. 确认脚本在检测到已有 PawnIO 时先执行卸载，再执行安装。
   Confirm an existing PawnIO installation is uninstalled before installation.

4. 确认 THRM 在流程结束后自动重新启动。
   Confirm THRM restarts when the flow completes.

5. 模拟安装器失败，确认 THRM 仍会重新启动。
   Simulate an installer failure and confirm THRM still restarts.

## Risk / Compatibility Notes

- 仅影响 Windows 上的 PawnIO 重装流程。
  This only affects the Windows PawnIO reinstall flow.

- 不修改用户配置、设备配置或现有界面文字。
  User configuration, device configuration, and existing UI copy are unchanged.